### PR TITLE
Adding Referrer to MagicLink

### DIFF
--- a/packages/magic-link/lib/MagicLink.js
+++ b/packages/magic-link/lib/MagicLink.js
@@ -47,6 +47,7 @@ class MagicLink {
      * @param {object} options
      * @param {string} options.email - The email to send magic link to
      * @param {string} options.requestSrc - The source magic link was requested from
+     * @param {string} options.referer - The url of the page the link was requested from
      * @param {TokenData} options.tokenData - The data for token
      * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
      * @returns {Promise<{token: Token, info: SentMessageInfo}>}
@@ -56,8 +57,9 @@ class MagicLink {
 
         const type = options.type || 'signin';
         const requestSrc = options.requestSrc || '';
+        const referer = Buffer.from(options.referer).toString('base64') || '';
 
-        const url = this.getSigninURL(token, type, requestSrc);
+        const url = `${this.getSigninURL(token, type, requestSrc)}&referer=${referer}`;
 
         const info = await this.transporter.sendMail({
             to: options.email,

--- a/packages/magic-link/lib/MagicLink.js
+++ b/packages/magic-link/lib/MagicLink.js
@@ -47,7 +47,6 @@ class MagicLink {
      * @param {object} options
      * @param {string} options.email - The email to send magic link to
      * @param {string} options.requestSrc - The source magic link was requested from
-     * @param {string} options.referer - The url of the page the link was requested from
      * @param {TokenData} options.tokenData - The data for token
      * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
      * @returns {Promise<{token: Token, info: SentMessageInfo}>}
@@ -57,9 +56,8 @@ class MagicLink {
 
         const type = options.type || 'signin';
         const requestSrc = options.requestSrc || '';
-        const referer = Buffer.from(options.referer).toString('base64') || '';
-
-        const url = `${this.getSigninURL(token, type, requestSrc)}&referer=${referer}`;
+      
+        const url = `${this.getSigninURL(token, type, requestSrc)}`;
 
         const info = await this.transporter.sendMail({
             to: options.email,

--- a/packages/magic-link/lib/MagicLink.js
+++ b/packages/magic-link/lib/MagicLink.js
@@ -57,7 +57,7 @@ class MagicLink {
         const type = options.type || 'signin';
         const requestSrc = options.requestSrc || '';
       
-        const url = `${this.getSigninURL(token, type, requestSrc)}`;
+        const url = this.getSigninURL(token, type, requestSrc);
 
         const info = await this.transporter.sendMail({
             to: options.email,

--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -208,7 +208,7 @@ module.exports = function MembersAPI({
 
     const users = memberRepository;
 
-    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}, requestSrc = ''}) {
+    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}, requestSrc = '', referer = ''}) {
         let type = requestedType;
         if (!options.forceEmailType) {
             const member = await users.get({email});
@@ -218,7 +218,7 @@ module.exports = function MembersAPI({
                 type = 'signup';
             }
         }
-        return magicLinkService.sendMagicLink({email, type, requestSrc, tokenData: Object.assign({email}, tokenData)});
+        return magicLinkService.sendMagicLink({email, type, requestSrc, tokenData: Object.assign({email}, tokenData), referer});
     }
 
     function getMagicLink(email) {

--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -208,7 +208,7 @@ module.exports = function MembersAPI({
 
     const users = memberRepository;
 
-    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}, requestSrc = '', referer = ''}) {
+    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}, requestSrc = ''}) {
         let type = requestedType;
         if (!options.forceEmailType) {
             const member = await users.get({email});
@@ -218,11 +218,16 @@ module.exports = function MembersAPI({
                 type = 'signup';
             }
         }
-        return magicLinkService.sendMagicLink({email, type, requestSrc, tokenData: Object.assign({email}, tokenData), referer});
+        return magicLinkService.sendMagicLink({email, type, requestSrc, tokenData: Object.assign({email}, tokenData)});
     }
 
     function getMagicLink(email) {
         return magicLinkService.getMagicLink({tokenData: {email}, type: 'signin'});
+    }
+
+    async function getRefererFromMagicLinkToken(token) {
+        const {referer} = await magicLinkService.getDataFromToken(token);
+        return referer;
     }
 
     async function getMemberDataFromMagicLinkToken(token) {
@@ -335,6 +340,7 @@ module.exports = function MembersAPI({
     return {
         middleware,
         getMemberDataFromMagicLinkToken,
+        getRefererFromMagicLinkToken,
         getMemberIdentityToken,
         getMemberIdentityData,
         setMemberGeolocationFromIp,

--- a/packages/members-api/lib/controllers/router.js
+++ b/packages/members-api/lib/controllers/router.js
@@ -286,6 +286,8 @@ module.exports = class RouterController {
 
     async sendMagicLink(req, res) {
         const {email, emailType, requestSrc} = req.body;
+        const {referer} = req.headers;
+
         if (!email) {
             res.writeHead(400);
             return res.end('Bad Request.');
@@ -296,11 +298,11 @@ module.exports = class RouterController {
                 const member = await this._memberRepository.get({email});
                 if (member) {
                     const tokenData = {};
-                    await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc});
+                    await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc, referer});
                 }
             } else {
                 const tokenData = _.pick(req.body, ['labels', 'name']);
-                await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc});
+                await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc, referer});
             }
             res.writeHead(201);
             return res.end('Created.');

--- a/packages/members-api/lib/controllers/router.js
+++ b/packages/members-api/lib/controllers/router.js
@@ -286,7 +286,8 @@ module.exports = class RouterController {
 
     async sendMagicLink(req, res) {
         const {email, emailType, requestSrc} = req.body;
-        const {referer} = req.headers;
+        const refHeader = req.headers.referer;
+        const referer = refHeader?(new URL(refHeader).pathname):'';
 
         if (!email) {
             res.writeHead(400);
@@ -297,12 +298,12 @@ module.exports = class RouterController {
             if (!this._allowSelfSignup()) {
                 const member = await this._memberRepository.get({email});
                 if (member) {
-                    const tokenData = {};
-                    await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc, referer});
+                    const tokenData = {referer};   
+                    await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc});
                 }
             } else {
-                const tokenData = _.pick(req.body, ['labels', 'name']);
-                await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc, referer});
+                const tokenData = {..._.pick(req.body, ['labels', 'name']), referer};
+                await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc});
             }
             res.writeHead(201);
             return res.end('Created.');


### PR DESCRIPTION
no issue

- Adds "referer" query param to the MagicLink class
- This will allow us to know where the user was when they initiated a signin, so we can send them back there instead of the homepage
- Includes this in the CTA button by appending it to the link before sending